### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: echo "VERSION=$(cat version.txt)" >> $GITHUB_OUTPUT
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docs-storefrontcloud-io/v2:${{ steps.get_version.outputs.VERSION }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore